### PR TITLE
Add people CPT

### DIFF
--- a/inc/cpt/people.php
+++ b/inc/cpt/people.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * People CPT (and related taxonomies)
+ *
+ * @package strikebase
+ */
+
+class Strikebase_Person {
+
+	/**
+	 * Singleton holder
+	 */
+	private static $__instance = null;
+
+	/**
+	 * Class variables
+	 */
+	private $cpt = 'person';
+
+	/**
+	 * Instantiate the singleton
+	 */
+	public static function get_instance() {
+		if ( ! is_a( self::$__instance, __CLASS__ ) ) {
+			self::$__instance = new self;
+		}
+		return self::$__instance;
+	}
+
+	/**
+	 * Add those actions to the init hook when the class is instantiated.
+	 */
+	private function __construct() {
+		add_action( 'init', array( $this, 'register_CPT' ) );
+		add_action( 'init', array( $this, 'register_taxonomies' ) );
+	}
+
+	/**
+	 * Register CPT and related taxonomies.
+	 *
+	 * @action init
+	 * @return null
+	 */
+	public function register_CPT() {
+		$cpt = array(
+			'labels'              => array(
+				'name'                => __( 'People', 'strikebase' ),
+				'singular_name'       => __( 'Person', 'strikebase' ),
+				'add_new'             => _x( 'Add New Person', 'strikebase', 'strikebase' ),
+				'add_new_item'        => __( 'Add New Person', 'strikebase' ),
+				'edit_item'           => __( 'Edit Person', 'strikebase' ),
+				'new_item'            => __( 'New Person', 'strikebase' ),
+				'view_item'           => __( 'View Person', 'strikebase' ),
+				'search_items'        => __( 'Search People', 'strikebase' ),
+				'not_found'           => __( 'No people found', 'strikebase' ),
+				'not_found_in_trash'  => __( 'No people found in Trash', 'strikebase' ),
+				'parent_item_colon'   => __( 'Person:', 'strikebase' ),
+				'menu_name'           => __( 'People', 'strikebase' ),
+			),
+			'menu_icon'	      => 'dashicons-groups',
+			'hierarchical'        => false,
+			'public'              => true,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'show_in_admin_bar'   => true,
+			'show_in_nav_menus'   => false,
+			'publicly_queryable'  => true,
+			'exclude_from_search' => false,
+			'has_archive'         => true,
+			'query_var'           => true,
+			'can_export'          => true,
+			'rewrite'             => array(
+				'with_front' => false,
+				'slug'       => 'people',
+			),
+			'capability_type'     => 'post',
+			'supports'            => array(
+				'title',
+				'editor',
+				'revisions'
+			),
+		);
+		register_post_type( $this->cpt, $cpt );
+	}
+
+	public function register_taxonomies() {
+
+		// Person organizationes
+		$organization_labels = array(
+			'name'                       => _x( 'Organization', 'Taxonomy General Name', 'strikebase' ),
+			'singular_name'              => _x( 'Organization', 'Taxonomy Singular Name', 'strikebase' ),
+			'menu_name'                  => __( 'Organizations', 'strikebase' ),
+			'all_items'                  => __( 'All Organizations', 'strikebase' ),
+			'new_item_name'              => __( 'New Organization', 'strikebase' ),
+			'add_new_item'               => __( 'Add New Organization', 'strikebase' ),
+			'edit_item'                  => __( 'Edit Organization', 'strikebase' ),
+			'update_item'                => __( 'Update Organization', 'strikebase' ),
+			'view_item'                  => __( 'View Organization', 'strikebase' ),
+			'separate_items_with_commas' => __( '', 'strikebase' ),
+			'add_or_remove_items'        => __( 'Add or remove items', 'strikebase' ),
+			'choose_from_most_used'      => __( 'Choose from the most used', 'strikebase' ),
+			'popular_items'              => __( 'Popular Organizations', 'strikebase' ),
+			'search_items'               => __( 'Search Organizations', 'strikebase' ),
+			'not_found'                  => __( 'Not Found', 'strikebase' ),
+			'no_terms'                   => __( 'No items', 'strikebase' ),
+			'items_list'                 => __( 'Organizations list', 'strikebase' ),
+			'items_list_navigation'      => __( 'Organizations list navigation', 'strikebase' ),
+		);
+		$organization_args = array(
+			'labels'                     => $organization_labels,
+			'hierarchical'               => true,
+			'public'                     => true,
+			'show_ui'                    => true,
+			'show_admin_column'          => true,
+			'show_in_nav_menus'          => true,
+			'show_tagcloud'              => false,
+		);
+		register_taxonomy( 'organization', array( $this->cpt, 'project' ), $organization_args );
+
+		// Type of person
+		$type_labels = array(
+			'name'                       => _x( 'Type of Person', 'Taxonomy General Name', 'strikebase' ),
+			'singular_name'              => _x( 'Type of Person', 'Taxonomy Singular Name', 'strikebase' ),
+			'menu_name'                  => __( 'Types of People', 'strikebase' ),
+			'all_items'                  => __( 'All Types of People', 'strikebase' ),
+			'new_item_name'              => __( 'New Type of Person', 'strikebase' ),
+			'add_new_item'               => __( 'Add New Person Type', 'strikebase' ),
+			'edit_item'                  => __( 'Edit Person Type', 'strikebase' ),
+			'update_item'                => __( 'Update Person Type', 'strikebase' ),
+			'view_item'                  => __( 'View Person Type', 'strikebase' ),
+			'separate_items_with_commas' => __( '', 'strikebase' ),
+			'add_or_remove_items'        => __( 'Add or remove items', 'strikebase' ),
+			'choose_from_most_used'      => __( 'Choose from the most used', 'strikebase' ),
+			'popular_items'              => __( 'Popular Types', 'strikebase' ),
+			'search_items'               => __( 'Search Types', 'strikebase' ),
+			'not_found'                  => __( 'Not Found', 'strikebase' ),
+			'no_terms'                   => __( 'No items', 'strikebase' ),
+			'items_list'                 => __( 'Types list', 'strikebase' ),
+			'items_list_navigation'      => __( 'Types list navigation', 'strikebase' ),
+		);
+		$type_args = array(
+			'labels'                     => $type_labels,
+			'hierarchical'               => false,
+			'public'                     => true,
+			'show_ui'                    => true,
+			'show_admin_column'          => true,
+			'show_in_nav_menus'          => true,
+			'show_tagcloud'              => true,
+		);
+		register_taxonomy( 'person-type', array( $this->cpt ), $type_args );
+	}
+}
+Strikebase_Person::get_instance();

--- a/inc/cpt/projects.php
+++ b/inc/cpt/projects.php
@@ -32,7 +32,7 @@ class Strikebase_Project {
 	 */
 	private function __construct() {
 		add_action( 'init', array( $this, 'register_CPT' ) );
-        add_action( 'init', array( $this, 'register_taxonomies' ) );
+		add_action( 'init', array( $this, 'register_taxonomies' ) );
 	}
 
 	/**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -48,6 +48,20 @@ function strikebase_show_organization() {
 }
 
 /*
+ * Display the type of person.
+ */
+function strikebase_show_person_type() {
+	echo strikebase_list_terms( 'person-type' );
+}
+
+/*
+ * Display the organization name.
+ */
+function strikebase_show_organization() {
+	echo strikebase_list_terms( 'organization' );
+}
+
+/*
  * Reusable snippet of code to output a list of terms.
  * Mostly used to list out custom taxonomies and do the comma thing sensibly.
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -34,6 +34,20 @@ function strikebase_show_project_host() {
 }
 
 /*
+ * Display the type of person.
+ */
+function strikebase_show_person_type() {
+	echo strikebase_list_terms( 'person-type' );
+}
+
+/*
+ * Display the organization name.
+ */
+function strikebase_show_organization() {
+	echo strikebase_list_terms( 'organization' );
+}
+
+/*
  * Reusable snippet of code to output a list of terms.
  * Mostly used to list out custom taxonomies and do the comma thing sensibly.
  *


### PR DESCRIPTION
This PR adds the "people" CPT and related taxonomies. I've included the organisation in this CPT, even though it's attached to both people and projects, because it's more closely linked to a person (I think). 

It also displays a listing of people and the individual person page.

Organisations still need a page but that's a bit more legwork, so I'm saving it for Monday. (See #14.)

Closes #2.