### PR TITLE
Add organization archive

### DIFF
--- a/archive-template-organization.php
+++ b/archive-template-organization.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Template Name: Organization list
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package strikebase
+ */
+get_header(); ?>
+
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+			<?php
+			/* Alrighty! So let's grab our organisations, first. */
+
+			$terms = get_terms( array(
+				'taxonomy' => 'organization',
+				'hide_empty' => false,
+				) );
+
+			if ( $terms ) : ?>
+
+			<table>
+				<thead>
+					<th><?php esc_html_e( 'Organization', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'People', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'Projects', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'Last contact', 'strikebase' ); ?></th>
+				</thead>
+
+				<?php
+				foreach ( $terms as $term ) :
+					// We're using locate_template here so we can pass our $terms array through.
+					// See http://mekshq.com/passing-variables-via-get_template_part-wordpress/
+					include( locate_template( 'components/organization/content-list.php', false, false ) );
+				endforeach;
+				?>
+
+			</table>
+		<?php else :
+			get_template_part( 'components/organization/content', 'none' );
+		endif; ?>
+
+		</main><!-- #main -->
+	</div><!-- #primary -->
+
+<?php
+get_footer();

--- a/components/organization/content-list.php
+++ b/components/organization/content-list.php
@@ -12,9 +12,7 @@
 
 
 	<td class="entry-title">
-		<a href="<?php echo esc_url( get_term_link( $term ) ); ?>">
-			<?php echo $term->name; ?>
-		</a>
+		<?php echo $term->name; ?>
 	</td>
 
 	<td class="strikebase-person-organization">

--- a/components/organization/content-list.php
+++ b/components/organization/content-list.php
@@ -18,11 +18,11 @@
 	</td>
 
 	<td class="strikebase-person-organization">
-		<?php strikebase_list_people( $term->slug ); ?>
+		<?php strikebase_list_org_attachments( $term->slug, 'person' ); ?>
 	</td>
 
 	<td class="strikebase-person-project">
-		Project 1, project 2
+		<?php strikebase_list_org_attachments( $term->slug, 'project' ); ?>
 	</td>
 
 	<td class="strikebase-person-last-contact">

--- a/components/organization/content-list.php
+++ b/components/organization/content-list.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Template part for displaying organizations in a list.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package strikebase
+ */
+?>
+
+<tr id="strikebase-<?php echo $term->slug; ?>">
+
+
+	<td class="entry-title">
+		<a href="<?php echo esc_url( get_term_link( $term ) ); ?>">
+			<?php echo $term->name; ?>
+		</a>
+	</td>
+
+	<td class="strikebase-person-organization">
+		Person 1, person 2
+	</td>
+
+	<td class="strikebase-person-project">
+		Project 1, project 2
+	</td>
+
+	<td class="strikebase-person-last-contact">
+		22 October 2016
+	</td>
+
+</tr><!-- #post-## -->

--- a/components/organization/content-list.php
+++ b/components/organization/content-list.php
@@ -18,7 +18,7 @@
 	</td>
 
 	<td class="strikebase-person-organization">
-		Person 1, person 2
+		<?php strikebase_list_people( $term->slug ); ?>
 	</td>
 
 	<td class="strikebase-person-project">

--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -14,9 +14,15 @@
 		<?php the_title( '<h2 class="entry-title">', '</h2>' ); ?>
 	</header><!-- .entry-header -->
 
-	<dl class="strikebase-project-info">
+	<dl class="strikebase-person-info">
+		<dt><?php esc_html_e( 'Type', 'strikebase' ); ?></dt>
+		<dd><?php strikebase_show_person_type(); ?></dd>
+
 		<dt><?php esc_html_e( 'Organization', 'strikebase' ); ?></dt>
 		<dd><?php strikebase_show_organization(); ?></dd>
+
+		<dt><?php esc_html_e( 'Projects', 'strikebase' ); ?></dt>
+		<dd>Project 1, Project 2</dd>
 	</dl>
 
 	<div class="entry-content">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -82,11 +82,11 @@ function strikebase_list_terms( $taxonomy ) {
  * This lists the people who belong to a specific organisation.
  * @TODO show gravatars!
  */
-function strikebase_list_people( $organization ) {
+function strikebase_list_org_attachments( $organization, $post_type ) {
 
 	// Query posts for people who belong to the org (taxonomy) specified
 	$args = array(
-		'post_type' => 'person',
+		'post_type' => $post_type,
 		'tax_query' => array(
 			array(
 				'taxonomy' => 'organization',

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -34,14 +34,6 @@ function strikebase_show_project_host() {
 }
 
 /*
-<<<<<<< HEAD
- * Display the type of person.
- */
-function strikebase_show_person_type() {
-	echo strikebase_list_terms( 'person-type' );
-}
-
-/*
  * Display the type of person.
  */
 function strikebase_show_person_type() {
@@ -111,7 +103,9 @@ function strikebase_list_people( $organization ) {
 
 		while ( $the_query->have_posts() ) :
 			$the_query->the_post();
+			$return .= '<a href="' . esc_url( get_the_permalink() ) . '">';
 			$return .= get_the_title();
+			$return .= '</a>';
 
 			// Use a comma as a separator.
 			if ( $the_query->current_post + 1 < $the_query->post_count ) :
@@ -122,7 +116,7 @@ function strikebase_list_people( $organization ) {
 
 		wp_reset_postdata();
 		echo $return;
-		
+
 	else :
 		return false;
 	endif;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -85,3 +85,45 @@ function strikebase_list_terms( $taxonomy ) {
 
 	return false;
 }
+
+/*
+ * This lists the people who belong to a specific organisation.
+ * @TODO show gravatars!
+ */
+function strikebase_list_people( $organization ) {
+
+	// Query posts for people who belong to the org (taxonomy) specified
+	$args = array(
+		'post_type' => 'person',
+		'tax_query' => array(
+			array(
+				'taxonomy' => 'organization',
+				'field'    => 'slug',
+				'terms'    => $organization,
+			),
+		),
+	);
+	$the_query = new WP_Query( $args );
+
+	// Loopity-loop!
+	if ( $the_query->have_posts() ) :
+		$return = '';
+
+		while ( $the_query->have_posts() ) :
+			$the_query->the_post();
+			$return .= get_the_title();
+
+			// Use a comma as a separator.
+			if ( $the_query->current_post + 1 < $the_query->post_count ) :
+				$return .= ', ';
+			endif;
+
+		endwhile;
+
+		wp_reset_postdata();
+		echo $return;
+		
+	else :
+		return false;
+	endif;
+}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -42,6 +42,13 @@ function strikebase_show_person_type() {
 }
 
 /*
+ * Display the type of person.
+ */
+function strikebase_show_person_type() {
+	echo strikebase_list_terms( 'person-type' );
+}
+
+/*
  * Display the organization name.
  */
 function strikebase_show_organization() {


### PR DESCRIPTION
This adds a pretty straightforward organization archive page, solving #14. 

It's using placeholders for one column ("date contacted") until we figure out how best to get/link that data. 