### PR TITLE
Fix funky taxonomy listing behaviour.

### DIFF
--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -16,7 +16,7 @@
 
 	<dl class="strikebase-person-info">
 		<dt><?php esc_html_e( 'Type', 'strikebase' ); ?></dt>
-		<dd><?php strikebase_show_person_type(); ?></dd>
+		<dd><?php strikebase_show_person_type( get_the_ID() ); ?></dd>
 
 		<dt><?php esc_html_e( 'Organization', 'strikebase' ); ?></dt>
 		<dd><?php strikebase_show_organization( get_the_ID() ); ?></dd>

--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -19,7 +19,7 @@
 		<dd><?php strikebase_show_person_type(); ?></dd>
 
 		<dt><?php esc_html_e( 'Organization', 'strikebase' ); ?></dt>
-		<dd><?php strikebase_show_organization(); ?></dd>
+		<dd><?php strikebase_show_organization( get_the_ID() ); ?></dd>
 
 		<dt><?php esc_html_e( 'Projects', 'strikebase' ); ?></dt>
 		<dd>Project 1, Project 2</dd>

--- a/components/person/content-list.php
+++ b/components/person/content-list.php
@@ -17,7 +17,7 @@
 	</td>
 
 	<td class="strikebase-person-organization">
-		<?php strikebase_show_organization(); ?>
+		<?php strikebase_show_organization( get_the_ID() ); ?>
 	</td>
 
 	<td class="strikebase-person-project">

--- a/components/project/content-full.php
+++ b/components/project/content-full.php
@@ -16,16 +16,16 @@
 
 	<dl class="strikebase-project-info">
 		<dt><?php esc_html_e( 'Status', 'strikebase' ); ?></dt>
-		<dd><?php strikebase_show_project_status(); ?></dd>
+		<dd><?php strikebase_show_project_status( get_the_ID() ); ?></dd>
 
 		<dt><?php esc_html_e( 'Genre', 'strikebase' ); ?></dt>
-		<dd><?php strikebase_show_project_genre(); ?></dd>
+		<dd><?php strikebase_show_project_genre( get_the_ID() ); ?></dd>
 
 		<dt><?php esc_html_e( 'Hosted on', 'strikebase' ); ?></dt>
-		<dd><?php strikebase_show_project_host(); ?></dd>
+		<dd><?php strikebase_show_project_host( get_the_ID() ); ?></dd>
 
 		<dt><?php esc_html_e( 'Type of project', 'strikebase' ); ?></dt>
-		<dd><?php strikebase_show_project_type(); ?></dd>
+		<dd><?php strikebase_show_project_type( get_the_ID() ); ?></dd>
 	</dl>
 
 	<div class="entry-content">

--- a/components/project/content-list.php
+++ b/components/project/content-list.php
@@ -17,7 +17,7 @@
 	</td>
 
 	<td class="strikebase-project-status">
-		<?php strikebase_show_project_status(); ?>
+		<?php strikebase_show_project_status( get_the_ID() ); ?>
 	</td>
 
 	<td class="strikebase-project-launch-date">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -8,43 +8,43 @@
 /*
  * Display the project status.
  */
-function strikebase_show_project_status() {
-	echo strikebase_list_terms( 'project-status' );
+function strikebase_show_project_status( $post_ID ) {
+	echo strikebase_list_terms( $post_ID, 'project-status' );
 }
 
 /*
  * Display the project genre.
  */
-function strikebase_show_project_genre() {
-	echo strikebase_list_terms( 'project-genre' );
+function strikebase_show_project_genre( $post_ID ) {
+	echo strikebase_list_terms( $post_ID, 'project-genre' );
 }
 
 /*
  * Display the project type.
  */
-function strikebase_show_project_type() {
-	echo strikebase_list_terms( 'project-type' );
+function strikebase_show_project_type( $post_ID ) {
+	echo strikebase_list_terms( $post_ID, 'project-type' );
 }
 
 /*
  * Display the project host.
  */
-function strikebase_show_project_host() {
-	echo strikebase_list_terms( 'project-host' );
+function strikebase_show_project_host( $post_ID ) {
+	echo strikebase_list_terms( $post_ID, 'project-host' );
 }
 
 /*
  * Display the type of person.
  */
-function strikebase_show_person_type() {
-	echo strikebase_list_terms( 'person-type' );
+function strikebase_show_person_type( $post_ID ) {
+	echo strikebase_list_terms( $post_ID, 'person-type' );
 }
 
 /*
  * Display the organization name.
  */
-function strikebase_show_organization() {
-	echo strikebase_list_terms( 'organization' );
+function strikebase_show_organization( $post_ID ) {
+	echo strikebase_list_terms( $post_ID, 'organization' );
 }
 
 /*
@@ -52,8 +52,8 @@ function strikebase_show_organization() {
  * Mostly used to list out custom taxonomies and do the comma thing sensibly.
  *
  */
-function strikebase_list_terms( $taxonomy ) {
-	$terms = get_terms( $taxonomy );
+function strikebase_list_terms( $post_ID, $taxonomy ) {
+	$terms = wp_get_post_terms( $post_ID, $taxonomy );
 
 	// Make sure we have some terms.
 	if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) :


### PR DESCRIPTION
I noticed, as I entered more data, that it looked as though *every single* person and project was attached to *every single* taxonomy term. That can't be right!

I was using get_terms() to get the taxonomy terms associated with my CPT.

At first, with minimal data, this seemed to work, except then I realised <duh> that just gets all the terms that exist ever and that's going to be totally useless and super confusing. 

So if we use wp_get_post_terms() instead and pass the post ID, everything is hunky-dory and it only returns the terms attached to our post.

Hurray!