### PR TITLE
Display custom meta values on frontend

### DIFF
--- a/components/organization/content-list.php
+++ b/components/organization/content-list.php
@@ -24,7 +24,7 @@
 	</td>
 
 	<td class="strikebase-person-last-contact">
-		22 October 2016
+		<strong>[LAST CONTACT DATE]</strong>
 	</td>
 
 </tr><!-- #post-## -->

--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -31,7 +31,7 @@
 
 		foreach ( $contact_info as $key => $value ) :
 			if ( $value ) :
-				echo '<dt>' . $key . '</dt>';
+				echo '<dt>' . strikebase_nice_key( $key ) . '</dt>';
 
 				if ( 'last_contacted' === $key ) :
 					echo '<dd>' . strikebase_formatted_date( $value ) . '</dd>';

--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -25,6 +25,25 @@
 		<dd>Project 1, Project 2</dd>
 	</dl>
 
+	<dl class="strikebase-contact-info">
+		<?php
+		$contact_info = strikebase_get_person_meta( get_the_ID() );
+
+		foreach ( $contact_info as $key => $value ) :
+			if ( $value ) :
+				echo '<dt>' . $key . '</dt>';
+
+				if ( 'last_contacted' === $key ) :
+					echo '<dd>' . strikebase_formatted_date( $value ) . '</dd>';
+				else :
+					echo '<dd>' . $value . '</dd>';
+				endif;
+
+			endif;
+		endforeach;
+		?>
+	</dl>
+
 	<div class="entry-content">
 		<div class="label"><?php esc_html_e( 'Notes', 'strikebase' ); ?></div>
 		<?php the_content(); ?>

--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -22,7 +22,7 @@
 		<dd><?php strikebase_show_organization( get_the_ID() ); ?></dd>
 
 		<dt><?php esc_html_e( 'Projects', 'strikebase' ); ?></dt>
-		<dd>Project 1, Project 2</dd>
+		<dd><strong>[LIST PROJECTS HERE]</strong></dd>
 	</dl>
 
 	<dl class="strikebase-contact-info">

--- a/components/person/content-list.php
+++ b/components/person/content-list.php
@@ -21,7 +21,7 @@
 	</td>
 
 	<td class="strikebase-person-project">
-		Project 1, project 2
+		<strong>[LIST PROJECTS HERE]</strong>
 	</td>
 
 	<td class="strikebase-project-last-contact">

--- a/components/person/content-list.php
+++ b/components/person/content-list.php
@@ -24,8 +24,13 @@
 		Project 1, project 2
 	</td>
 
-	<td class="strikebase-person-last-contact">
-		22 October 2016
+	<td class="strikebase-project-last-contact">
+		<?php
+		$dates = strikebase_get_person_meta( get_the_ID() );
+		if ( $dates['last_contacted'] ) :
+			echo strikebase_formatted_date( $dates['last_contacted'] );
+		endif;
+		?>
 	</td>
 
 </tr><!-- #post-## -->

--- a/components/project/content-full.php
+++ b/components/project/content-full.php
@@ -46,7 +46,7 @@
 		foreach ( $dates as $key => $value ) :
 			if ( $value ) :
 				echo '<dt>' . $key . '</dt>';
-				echo '<dd>' . $value . '</dd>';
+				echo '<dd>' . strikebase_formatted_date( $value ) . '</dd>';
 			endif;
 		endforeach;
 		?>

--- a/components/project/content-full.php
+++ b/components/project/content-full.php
@@ -30,7 +30,7 @@
 
 	<dl class="strikebase-people">
 		<?php
-		$people = strikebase_get_post_meta( get_the_ID(), 'people' );
+		$people = strikebase_get_project_meta( get_the_ID(), 'people' );
 		foreach ( $people as $key => $value ) :
 			if ( $value ) :
 				echo '<dt>' . $key . '</dt>';
@@ -42,7 +42,7 @@
 
 	<dl class="strikebase-dates">
 		<?php
-		$dates = strikebase_get_post_meta( get_the_ID(), 'dates' );
+		$dates = strikebase_get_project_meta( get_the_ID(), 'dates' );
 		foreach ( $dates as $key => $value ) :
 			if ( $value ) :
 				echo '<dt>' . $key . '</dt>';
@@ -54,7 +54,7 @@
 
 	<dl class="strikebase-links">
 		<?php
-		$links = strikebase_get_post_meta( get_the_ID(), 'links' );
+		$links = strikebase_get_project_meta( get_the_ID(), 'links' );
 		foreach ( $links as $key => $value ) :
 			if ( $value ) :
 				echo '<dt>' . $key . '</dt>';

--- a/components/project/content-full.php
+++ b/components/project/content-full.php
@@ -58,7 +58,7 @@
 		foreach ( $links as $key => $value ) :
 			if ( $value ) :
 				echo '<dt>' . $key . '</dt>';
-				echo '<dd><a href="' . $value . '">' . $value . '</a></dd>';
+				echo '<dd><a href="' . $value . '">' . strikebase_simplify_URL( $value ) . '</a></dd>';
 			endif;
 		endforeach;
 		?>

--- a/components/project/content-full.php
+++ b/components/project/content-full.php
@@ -33,7 +33,7 @@
 		$people = strikebase_get_project_meta( get_the_ID(), 'people' );
 		foreach ( $people as $key => $value ) :
 			if ( $value ) :
-				echo '<dt>' . $key . '</dt>';
+				echo '<dt>' . strikebase_nice_key( $key ) . '</dt>';
 				echo '<dd>' . $value . '</dd>';
 			endif;
 		endforeach;
@@ -45,7 +45,7 @@
 		$dates = strikebase_get_project_meta( get_the_ID(), 'dates' );
 		foreach ( $dates as $key => $value ) :
 			if ( $value ) :
-				echo '<dt>' . $key . '</dt>';
+				echo '<dt>' . strikebase_nice_key( $key ) . '</dt>';
 				echo '<dd>' . strikebase_formatted_date( $value ) . '</dd>';
 			endif;
 		endforeach;
@@ -57,7 +57,7 @@
 		$links = strikebase_get_project_meta( get_the_ID(), 'links' );
 		foreach ( $links as $key => $value ) :
 			if ( $value ) :
-				echo '<dt>' . $key . '</dt>';
+				echo '<dt>' . strikebase_nice_key( $key ) . '</dt>';
 				echo '<dd><a href="' . $value . '">' . strikebase_simplify_URL( $value ) . '</a></dd>';
 			endif;
 		endforeach;

--- a/components/project/content-full.php
+++ b/components/project/content-full.php
@@ -28,6 +28,42 @@
 		<dd><?php strikebase_show_project_type( get_the_ID() ); ?></dd>
 	</dl>
 
+	<dl class="strikebase-people">
+		<?php
+		$people = strikebase_get_post_meta( get_the_ID(), 'people' );
+		foreach ( $people as $key => $value ) :
+			if ( $value ) :
+				echo '<dt>' . $key . '</dt>';
+				echo '<dd>' . $value . '</dd>';
+			endif;
+		endforeach;
+		?>
+	</dl>
+
+	<dl class="strikebase-dates">
+		<?php
+		$dates = strikebase_get_post_meta( get_the_ID(), 'dates' );
+		foreach ( $dates as $key => $value ) :
+			if ( $value ) :
+				echo '<dt>' . $key . '</dt>';
+				echo '<dd>' . $value . '</dd>';
+			endif;
+		endforeach;
+		?>
+	</dl>
+
+	<dl class="strikebase-links">
+		<?php
+		$links = strikebase_get_post_meta( get_the_ID(), 'links' );
+		foreach ( $links as $key => $value ) :
+			if ( $value ) :
+				echo '<dt>' . $key . '</dt>';
+				echo '<dd><a href="' . $value . '">' . $value . '</a></dd>';
+			endif;
+		endforeach;
+		?>
+	</dl>
+
 	<div class="entry-content">
 		<div class="label"><?php esc_html_e( 'Notes', 'strikebase' ); ?></div>
 		<?php the_content(); ?>

--- a/components/project/content-list.php
+++ b/components/project/content-list.php
@@ -22,7 +22,7 @@
 
 	<td class="strikebase-project-launch-date">
 		<?php
-		$dates = strikebase_get_post_meta( get_the_ID(), 'dates' );
+		$dates = strikebase_get_project_meta( get_the_ID(), 'dates' );
 		if ( $dates['launch'] ) :
 			echo strikebase_formatted_date( $dates['launch'] );
 		elseif ( $dates['est_launch'] ) :

--- a/components/project/content-list.php
+++ b/components/project/content-list.php
@@ -21,11 +21,23 @@
 	</td>
 
 	<td class="strikebase-project-launch-date">
-		18 July 2016
+		<?php
+		$dates = strikebase_get_post_meta( get_the_ID(), 'dates' );
+		if ( $dates['launch'] ) :
+			echo strikebase_formatted_date( $dates['launch'] );
+		elseif ( $dates['est_launch'] ) :
+			echo strikebase_formatted_date( $dates['est_launch'] );
+			esc_html_e( ' (estimated)', 'strikebase' );
+		endif;
+		?>
 	</td>
 
 	<td class="strikebase-project-last-contact">
-		22 October 2016
+		<?php
+		if ( $dates['last_contacted'] ) :
+			echo strikebase_formatted_date( $dates['last_contacted'] );
+		endif;
+		?>
 	</td>
 
 </tr><!-- #post-## -->

--- a/inc/cpt/projects/class-projects-custom-fields.php
+++ b/inc/cpt/projects/class-projects-custom-fields.php
@@ -42,8 +42,7 @@ class Strikebase_Project_Fields {
 	 */
 	public function add_project_fields() {
 		$project_fields = new Fieldmanager_Group( array(
-			'name'     => 'person_contact_info',
-			//'label'    => esc_html__( 'Contact Info', 'strikebase' ),
+			'name'     => 'project_info',
 			'children' => array(
 				'people' => new Fieldmanager_Group( array(
 					'name'  => 'people',

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -52,8 +52,12 @@ function strikebase_show_organization( $post_ID ) {
  */
 function strikebase_get_post_meta( $post_ID, $key ) {
 	$metas = get_post_meta( get_the_ID(), 'project_info', false );
-	$array = $metas[0][$key];
-	return $array;
+	if ( $metas ) :
+		$array = $metas[0][$key];
+		return $array;
+	else :
+		return false;
+	endif;
 }
 
 /*

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -48,6 +48,15 @@ function strikebase_show_organization( $post_ID ) {
 }
 
 /*
+ * Get an array of custom metadata attached to a given post.
+ */
+function strikebase_get_post_meta( $post_ID, $key ) {
+	$metas = get_post_meta( get_the_ID(), 'project_info', false );
+	$array = $metas[0][$key];
+	return $array;
+}
+
+/*
  * Reusable snippet of code to output a list of terms.
  * Mostly used to list out custom taxonomies and do the comma thing sensibly.
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -61,6 +61,19 @@ function strikebase_get_project_meta( $post_ID, $key ) {
 }
 
 /*
+ * Get an array of custom metadata attached to a given person.
+ */
+function strikebase_get_person_meta( $post_ID ) {
+	$metas = get_post_meta( get_the_ID(), 'person_contact_info', false );
+	if ( $metas ) :
+		$array = $metas[0];
+		return $array;
+	else :
+		return false;
+	endif;
+}
+
+/*
  * Simplify a URL.
  */
 function strikebase_simplify_URL( $URL ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -57,6 +57,30 @@ function strikebase_get_post_meta( $post_ID, $key ) {
 }
 
 /*
+ * Simplify a URL.
+ */
+function strikebase_simplify_URL( $URL ) {
+	// Remove extra slashes.
+	$simple_URL = trim( $URL, '/' );
+
+	// If protocol is included, strip it out.
+	if ( substr($simple_URL, 0, 7) == 'http://' ) {
+		$simple_URL = substr($simple_URL, 7);
+	}
+	
+	if ( substr($simple_URL, 0, 8) == 'https://' ) {
+		$simple_URL = substr($simple_URL, 8);
+	}
+
+	// Remove the 'www.' prefix.
+	if ( substr($simple_URL, 0, 4) == 'www.') {
+		$simple_URL = substr($simple_URL, 4);
+	}
+
+	return $simple_URL;
+}
+
+/*
  * Reusable snippet of code to output a list of terms.
  * Mostly used to list out custom taxonomies and do the comma thing sensibly.
  *
@@ -99,8 +123,8 @@ function strikebase_list_org_attachments( $organization, $post_type ) {
 		'tax_query' => array(
 			array(
 				'taxonomy' => 'organization',
-				'field'    => 'slug',
-				'terms'    => $organization,
+				'field'	 => 'slug',
+				'terms'	 => $organization,
 			),
 		),
 	);

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -48,9 +48,9 @@ function strikebase_show_organization( $post_ID ) {
 }
 
 /*
- * Get an array of custom metadata attached to a given post.
+ * Get an array of custom metadata attached to a given project.
  */
-function strikebase_get_post_meta( $post_ID, $key ) {
+function strikebase_get_project_meta( $post_ID, $key ) {
 	$metas = get_post_meta( get_the_ID(), 'project_info', false );
 	if ( $metas ) :
 		$array = $metas[0][$key];

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -67,7 +67,7 @@ function strikebase_simplify_URL( $URL ) {
 	if ( substr($simple_URL, 0, 7) == 'http://' ) {
 		$simple_URL = substr($simple_URL, 7);
 	}
-	
+
 	if ( substr($simple_URL, 0, 8) == 'https://' ) {
 		$simple_URL = substr($simple_URL, 8);
 	}
@@ -78,6 +78,18 @@ function strikebase_simplify_URL( $URL ) {
 	}
 
 	return $simple_URL;
+}
+
+/*
+ * Output a nice human-parseable date.
+ */
+function strikebase_formatted_date( $date, $date_format=null ) {
+	if ( ! $date_format ) :
+		// If we haven't explicitly set a date format, pull it from WordPress options
+		$date_format = get_option( 'date_format' );
+	endif;
+	$formatted_date = date( $date_format, $date );
+	return $formatted_date;
 }
 
 /*

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -110,6 +110,32 @@ function strikebase_formatted_date( $date, $date_format=null ) {
 }
 
 /*
+ * Tweak the display of a given label for a custom meta key.
+ * In some cases, these labels aren't quite as descriptive as they should be,
+ * so we're going to manually fine-tune them.
+ */
+function strikebase_nice_key( $key ) {
+	// Replace underscores with a space.
+	$nice_key = str_replace( '_', ' ', $key );
+
+	// Expand "launch", "est launch", and "last contacted".
+	if ( 'est_launch' === $key ) :
+		$nice_key = 'Estimated Launch Date';
+	elseif ( 'launch' === $key ) :
+		$nice_key = 'Launch Date';
+	elseif ( 'last_contacted' === $key ) :
+		$nice_key = 'Last Contacted On';
+	endif;
+
+	// Expand "username".
+	if ( 'username' === $key ) :
+		$nice_key = 'WordPress.com Username';
+	endif;
+
+	return $nice_key;
+}
+
+/*
  * Reusable snippet of code to output a list of terms.
  * Mostly used to list out custom taxonomies and do the comma thing sensibly.
  *


### PR DESCRIPTION
This displays the custom meta values, implemented in #19, on the front end. So: the project listing page, the project details page, the people listing page, and the people details page. 

This means that most of the data shown on the frontend is now coming directly from the database, yayyyyy. (I've bolded anything that isn't coming from the database so we can more easily identify those gaps, but right now it's mostly #12 that's causing the missing data.)

@danielwrobert, I'd love a review & merge whenever you've a moment! Once this is all merged we'll have all the data available on the front-end, and I'll be able to start working on actual design stuff. 