### PR TITLE
Configure timezone input as a select or autocomplete.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -132,6 +132,11 @@ require get_template_directory() . '/inc/jetpack.php';
 require get_template_directory() . '/inc/template-tags.php';
 
 /**
+ * Load custom date & time functionality.
+ */
+require get_template_directory() . '/inc/date-and-time.php';
+
+/**
  * Create a projects CPT.
  */
 require get_template_directory() . '/inc/cpt/projects/class-projects-post-type.php';

--- a/inc/cpt/people/class-people-custom-fields.php
+++ b/inc/cpt/people/class-people-custom-fields.php
@@ -34,6 +34,14 @@ class Strikebase_Person_Fields {
 		add_action( 'fm_post_person', array( $this, 'add_person_fields' ) );
 	}
 
+	/*
+	 * Get a list of all the timezones PHP supports.
+	 */
+	private function get_timezones() {
+		$timezone_list = DateTimeZone::listIdentifiers( DateTimeZone::ALL );
+		return $tzlist;
+	}
+
 	/**
 	 * Add custom fields for Person post type
 	 *
@@ -57,9 +65,12 @@ class Strikebase_Person_Fields {
 					'name'  => 'phone',
 					'label' => esc_html__( 'Phone Number(s)', 'strikebase' ),
 				) ),
-				'time_zone' => new Fieldmanager_Textfield( array(
+				'time_zone' => new Fieldmanager_Autocomplete( array(
 					'name'  => 'time_zone',
-					'label' => esc_html__( 'Timezone', 'strikebase' ),
+					'label' => esc_html__( 'Time Zone', 'strikebase' ),
+					'datasource'  => new Fieldmanager_Datasource( array(
+						'options' => self::get_timezones(),
+					) ),
 				) ),
 
 				// Social media accounts.

--- a/inc/cpt/people/class-people-custom-fields.php
+++ b/inc/cpt/people/class-people-custom-fields.php
@@ -34,14 +34,6 @@ class Strikebase_Person_Fields {
 		add_action( 'fm_post_person', array( $this, 'add_person_fields' ) );
 	}
 
-	/*
-	 * Get a list of all the timezones PHP supports.
-	 */
-	private function get_timezones() {
-		$timezone_list = DateTimeZone::listIdentifiers( DateTimeZone::ALL );
-		return $tzlist;
-	}
-
 	/**
 	 * Add custom fields for Person post type
 	 *
@@ -65,11 +57,11 @@ class Strikebase_Person_Fields {
 					'name'  => 'phone',
 					'label' => esc_html__( 'Phone Number(s)', 'strikebase' ),
 				) ),
-				'time_zone' => new Fieldmanager_Autocomplete( array(
+				'time_zone' => new Fieldmanager_Select( array(
 					'name'  => 'time_zone',
 					'label' => esc_html__( 'Time Zone', 'strikebase' ),
 					'datasource'  => new Fieldmanager_Datasource( array(
-						'options' => self::get_timezones(),
+						'options' => strikebase_get_timezones(),
 					) ),
 				) ),
 

--- a/inc/date-and-time.php
+++ b/inc/date-and-time.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Custom functionality related to date and time calculations.
+ *
+ * @package strikebase
+ */
+
+/*
+ * Output a nice human-parseable date.
+ */
+function strikebase_formatted_date( $date, $date_format=null ) {
+	if ( ! $date_format ) :
+		// If we haven't explicitly set a date format, pull it from WordPress options
+		$date_format = get_option( 'date_format' );
+	endif;
+	$formatted_date = date( $date_format, $date );
+	return $formatted_date;
+}
+
+/*
+ * Get a list of all the timezones PHP supports.
+ */
+function strikebase_get_timezones() {
+
+	// Create arrays for the timezone and its offset/
+	$timezone_list = [];
+	$GMT_offsets = [];
+	$now = new DateTime( 'now', new DateTimeZone('UTC') );
+
+	foreach ( DateTimeZone::listIdentifiers() as $timezone ) :
+		$now->setTimezone( new DateTimeZone($timezone) );
+		$GMT_offsets[] = $GMT_offset = $now->getOffset();
+		$timezone_list[$timezone] = '(' . strikebase_format_GMT_offset( $GMT_offset ) . ') ' . strikebase_format_timezone_name( $timezone );
+	endforeach;
+
+	// Sort by GMT offset first, then by timezone name.
+	array_multisort( $GMT_offsets, $timezone_list );
+
+	return $timezone_list;
+}
+
+/*
+ * Format a given timezone's GMT offset.
+ */
+function strikebase_format_GMT_offset( $offset ) {
+	$hours = intval( $offset / 3600 );
+	$minutes = abs( intval( $offset % 3600 / 60 ) );
+	return 'GMT' . ( $offset ? sprintf( '%+03d:%02d', $hours, $minutes ) : '' );
+}
+
+/*
+ * Format the name of a timezone in a more human-friendly way.
+ */
+function strikebase_format_timezone_name( $timezone_name ) {
+	$timezone_name = str_replace( '/', ', ', $timezone_name );
+	$timezone_name = str_replace( '_', ' ', $timezone_name );
+	$timezone_name = str_replace( 'St ', 'St. ', $timezone_name );
+	return $timezone_name;
+}

--- a/inc/date-and-time.php
+++ b/inc/date-and-time.php
@@ -52,8 +52,27 @@ function strikebase_format_GMT_offset( $offset ) {
  * Format the name of a timezone in a more human-friendly way.
  */
 function strikebase_format_timezone_name( $timezone_name ) {
-	$timezone_name = str_replace( '/', ', ', $timezone_name );
-	$timezone_name = str_replace( '_', ' ', $timezone_name );
-	$timezone_name = str_replace( 'St ', 'St. ', $timezone_name );
-	return $timezone_name;
+
+	// Separate out continent and region data, if they exist.
+	$timezone_pieces = explode( '/', $timezone_name );
+	if ( 2 === count( $timezone_pieces ) ) :
+		$continent = $timezone_pieces[0];
+		$formatted_timezone_name = $timezone_pieces[1];
+		// $formatted_timezone_name = $timezone_pieces[1] . ' ('. $continent .')';
+	elseif ( 3 === count( $timezone_pieces ) ) :
+			$continent = $timezone_pieces[0];
+			$region = $timezone_pieces[1];
+			$formatted_timezone_name = $timezone_pieces[2] . ', '. $region;
+			// $formatted_timezone_name = $timezone_pieces[2] . ', '. $region  . ' ('. $continent .')';
+	else:
+		$formatted_timezone_name = $timezone_name;
+	endif;
+
+	// Replace any underscores with spaces.
+	$formatted_timezone_name = str_replace( '_', ' ', $formatted_timezone_name );
+
+	// Swap "St" for "St.".
+	$formatted_timezone_name = str_replace( 'St ', 'St. ', $formatted_timezone_name );
+
+	return $formatted_timezone_name;
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -150,18 +150,6 @@ function strikebase_simplify_URL( $URL ) {
 }
 
 /*
- * Output a nice human-parseable date.
- */
-function strikebase_formatted_date( $date, $date_format=null ) {
-	if ( ! $date_format ) :
-		// If we haven't explicitly set a date format, pull it from WordPress options
-		$date_format = get_option( 'date_format' );
-	endif;
-	$formatted_date = date( $date_format, $date );
-	return $formatted_date;
-}
-
-/*
  * Tweak the display of a given label for a custom meta key.
  * In some cases, these labels aren't quite as descriptive as they should be,
  * so we're going to manually fine-tune them.


### PR DESCRIPTION
In order to ensure we have consistent data for a person's timezone, we're using a list of PHP-supported timezones. This should make it easier for PHP to handle the output of the field.

The timezone list as output by PHP is suuuuuper long, so I've configured this as an autocomplete for the moment. This works nicely if you're in a major city, but is obviously less ideal if you're not. (For instance, if I enter "London" it gives me London, but "Edinburgh" won't work.) Guessing in these cases is often easier with a giant select box, but an autocomplete is easier to use if you know the best major city nearby to code it to.

Additionally, the output is currently using underscores, so a search for "New York" won't return any results. Pretty easy fix if we decide an autocomplete is the better option here, although I'm not convinced it is.

Fixes #21.
