### PR TITLE
Tweak 'date last contacted' display & behaviour.

### DIFF
--- a/archive-person.php
+++ b/archive-person.php
@@ -19,7 +19,6 @@ get_header(); ?>
 					<th><?php esc_html_e( 'Name', 'strikebase' ); ?></th>
 					<th><?php esc_html_e( 'Organization', 'strikebase' ); ?></th>
 					<th><?php esc_html_e( 'Projects', 'strikebase' ); ?></th>
-					<th><?php esc_html_e( 'Last contact', 'strikebase' ); ?></th>
 				</thead>
 			<?php
 			/* Start the Loop */

--- a/archive-project.php
+++ b/archive-project.php
@@ -19,7 +19,7 @@ get_header(); ?>
 					<th><?php esc_html_e( 'Project', 'strikebase' ); ?></th>
 					<th><?php esc_html_e( 'Status', 'strikebase' ); ?></th>
 					<th><?php esc_html_e( 'Launch date', 'strikebase' ); ?></th>
-					<th><?php esc_html_e( 'Last contact', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'Last check-in', 'strikebase' ); ?></th>
 				</thead>
 			<?php
 			/* Start the Loop */

--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -33,13 +33,6 @@
 			foreach ( $contact_info as $key => $value ) :
 				if ( $value ) :
 					echo '<dt>' . strikebase_nice_key( $key ) . '</dt>';
-
-					if ( 'last_contacted' === $key ) :
-						echo '<dd>' . strikebase_formatted_date( $value ) . '</dd>';
-					else :
-						echo '<dd>' . $value . '</dd>';
-					endif;
-
 				endif;
 			endforeach;
 		endif;

--- a/components/person/content-list.php
+++ b/components/person/content-list.php
@@ -24,13 +24,4 @@
 		<strong>[LIST PROJECTS HERE]</strong>
 	</td>
 
-	<td class="strikebase-project-last-contact">
-		<?php
-		$dates = strikebase_get_person_meta( get_the_ID() );
-		if ( $dates['last_contacted'] ) :
-			echo strikebase_formatted_date( $dates['last_contacted'] );
-		endif;
-		?>
-	</td>
-
 </tr><!-- #post-## -->

--- a/components/project/content-list.php
+++ b/components/project/content-list.php
@@ -34,8 +34,8 @@
 
 	<td class="strikebase-project-last-contact">
 		<?php
-		if ( $dates['last_contacted'] ) :
-			echo strikebase_formatted_date( $dates['last_contacted'] );
+		if ( $dates AND array_key_exists( 'last_check_in', $dates ) ) :
+			echo strikebase_formatted_date( $dates['last_check_in'] );
 		endif;
 		?>
 	</td>

--- a/inc/cpt/people/class-people-custom-fields.php
+++ b/inc/cpt/people/class-people-custom-fields.php
@@ -65,10 +65,6 @@ class Strikebase_Person_Fields {
 					'name'  => 'social_media',
 					'label' => esc_html__( 'Social Media Accounts', 'strikebase' ),
 				) ),
-				'last_contacted' => new Fieldmanager_Datepicker( array(
-					'name'  => 'last_contacted',
-					'label' => esc_html__( 'Date Last Contacted', 'strikebase' ),
-				) ),
 			)
 		) );
 

--- a/inc/cpt/projects/class-projects-custom-fields.php
+++ b/inc/cpt/projects/class-projects-custom-fields.php
@@ -136,9 +136,9 @@ class Strikebase_Project_Fields {
 							'name'  => 'launch',
 							'label' => esc_html__( 'Actual Launch Date', 'strikebase' ),
 						) ),
-						'last_contacted' => new Fieldmanager_Datepicker( array(
-							'name'  => 'last_contacted',
-							'label' => esc_html__( 'Date Last Contacted', 'strikebase' ),
+						'last_check_in' => new Fieldmanager_Datepicker( array(
+							'name'  => 'last_check_in',
+							'label' => esc_html__( 'Date of last check-in', 'strikebase' ),
 						) ),
 					)
 				) ),

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -123,8 +123,8 @@ function strikebase_nice_key( $key ) {
 		$nice_key = 'Estimated Launch Date';
 	elseif ( 'launch' === $key ) :
 		$nice_key = 'Launch Date';
-	elseif ( 'last_contacted' === $key ) :
-		$nice_key = 'Last Contacted On';
+	elseif ( 'last_check_in' === $key ) :
+		$nice_key = 'Last Check-in';
 	endif;
 
 	// Expand "username".


### PR DESCRIPTION
As per discussion in #25, I've removed the 'date last contacted' field entirely from people (we can re-add this if we decide it will add value later, and pull that data from Zendesk's API) and I've also renamed the 'date last contacted' field for projects to 'date of last check-in' so it's a bit more clear.

Fixes #25.