### PR TITLE
Add template for project statuses.

### DIFF
--- a/assets/stylesheets/layout/_layout.scss
+++ b/assets/stylesheets/layout/_layout.scss
@@ -23,6 +23,11 @@ body {
 
 @import "masthead";
 
+/* Center-align page headers on archive pages. */
+.archive .page-header {
+	text-align: center;
+}
+
 /*--------------------------------------------------------------
 ## People & projects CPT
 --------------------------------------------------------------*/

--- a/style.css
+++ b/style.css
@@ -687,6 +687,10 @@ body {
 .site-title {
   font-size: 3em; }
 
+/* Center-align page headers on archive pages. */
+.archive .page-header {
+  text-align: center; }
+
 /*--------------------------------------------------------------
 ## People & projects CPT
 --------------------------------------------------------------*/

--- a/taxonomy-project-status.php
+++ b/taxonomy-project-status.php
@@ -11,6 +11,13 @@ get_header(); ?>
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 
+			<header class="page-header">
+				<?php
+					the_archive_title( '<h1 class="page-title">', '</h1>' );
+					the_archive_description( '<div class="archive-description">', '</div>' );
+				?>
+			</header><!-- .page-header -->
+
 		<?php
 		if ( have_posts() ) : ?>
 

--- a/taxonomy-project-status.php
+++ b/taxonomy-project-status.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * The template for displaying a list of all projects.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package strikebase
+ */
+get_header(); ?>
+
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+		<?php
+		if ( have_posts() ) : ?>
+
+			<table>
+				<thead>
+					<th><?php esc_html_e( 'Project', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'Launch date', 'strikebase' ); ?></th>
+					<th><?php esc_html_e( 'Last contact', 'strikebase' ); ?></th>
+				</thead>
+			<?php
+			/* Start the Loop */
+			while ( have_posts() ) : the_post();
+				get_template_part( 'components/project/content', 'list' );
+			endwhile;
+			the_posts_navigation();
+			?>
+
+			</table>
+		<?php else :
+			get_template_part( 'components/project/content', 'none' );
+		endif; ?>
+
+		</main><!-- #main -->
+	</div><!-- #primary -->
+
+<?php
+get_footer();


### PR DESCRIPTION
This adds a template page so we can view projects by status on a single page, ie http://strikebase.dev/project-status/cold/

Solves #40 but may be rendered moot if we implement #48. Right now, I haven't cross-linked (see #45 for discussion) anywhere because I think filtering the project page would actually be the most sensible choice here. If we need a way of viewing projects by status prior to that though, I think this would be worth implementing.