### PR TITLE
Add check-in date to org page.

### DIFF
--- a/components/organization/content-list.php
+++ b/components/organization/content-list.php
@@ -24,7 +24,7 @@
 	</td>
 
 	<td class="strikebase-person-last-contact">
-		<strong>[LAST CONTACT DATE]</strong>
+		<?php strikebase_show_checkin_date( $term->slug ); ?>
 	</td>
 
 </tr><!-- #post-## -->


### PR DESCRIPTION
This replaces the placeholder with an actual check-in date, so we can see at a glance when we last contacted an organisation. Works by getting the projects associated with an org, then get all the check-in dates of those projects, finding the most recent one, and outputting it.

Fixes #47.