### PR TITLE
Display gravatars for users with email addresses. Fixes #51.

### DIFF
--- a/components/person/content-full.php
+++ b/components/person/content-full.php
@@ -11,6 +11,13 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 	<header class="entry-header">
+		<?php
+			$contact_info = strikebase_get_person_meta( get_the_ID() );
+			if ( $contact_info['email'] ) :
+				echo '<img class="gravatar" src="'. strikebase_get_gravatar( $contact_info['email'] ) . '?s=200&&d=mm" />';
+			endif;
+		?>
+
 		<?php the_title( '<h2 class="entry-title">', '</h2>' ); ?>
 	</header><!-- .entry-header -->
 
@@ -29,7 +36,6 @@
 
 		<dl class="strikebase-contact-info">
 			<?php
-			$contact_info = strikebase_get_person_meta( get_the_ID() );
 
 			if ( $contact_info ) :
 				if ( $contact_info ) :

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -58,3 +58,12 @@ function strikebase_numeric_pagination( $page_count = 9, $query = null ) {
 
 	echo '</div>';
 }
+
+/*
+ * Get gravatar for a given email address.
+ *
+ */
+function strikebase_get_gravatar( $email ) {
+	$hash = md5( strtolower( trim( $email ) ) );
+	return "//www.gravatar.com/avatar/" . $hash;
+}


### PR DESCRIPTION
This is super-simple—just displays a gravatar on the person's detail page, so they're a bit more human-feeling. I'm using this in the design work in #60, so I figured I'd get some real data to work with. :)