### PR TITLE
Updated action hook for Custom Fields

### DIFF
--- a/inc/custom-fields/class-fields-person.php
+++ b/inc/custom-fields/class-fields-person.php
@@ -11,7 +11,7 @@ class Strikebase_Person_Fields extends Strikebase_Fields {
 	 *
 	 * @var array
 	 */
-	protected $post_types = array( 'person' );
+	protected $post_type = 'person';
 
 	/**
 	 * Create and register custom fields
@@ -69,7 +69,7 @@ class Strikebase_Person_Fields extends Strikebase_Fields {
 				) ),
 			),
 		) );
-		$person_fields->add_meta_box( esc_html__( 'Contact Info', 'strikebase' ), $this->post_types );
+		$person_fields->add_meta_box( esc_html__( 'Contact Info', 'strikebase' ), $this->post_type );
 	}
 }
 

--- a/inc/custom-fields/class-fields-project.php
+++ b/inc/custom-fields/class-fields-project.php
@@ -11,7 +11,7 @@ class Strikebase_Project_Fields extends Strikebase_Fields {
 	 *
 	 * @var array
 	 */
-	protected $post_types = array( 'project' );
+	protected $post_type = 'project';
 
 	/**
 	 * Create and register custom fields
@@ -150,7 +150,7 @@ class Strikebase_Project_Fields extends Strikebase_Fields {
 				) ),
 			),
 		) );
-		$project_fields->add_meta_box( esc_html__( 'Project Info', 'strikebase' ), $this->post_types );
+		$project_fields->add_meta_box( esc_html__( 'Project Info', 'strikebase' ), $this->post_type );
 	}
 }
 

--- a/inc/custom-fields/class-fields.php
+++ b/inc/custom-fields/class-fields.php
@@ -21,7 +21,7 @@ abstract class Strikebase_Fields {
 	 *
 	 * @var array
 	 */
-	protected $post_types = null;
+	protected $post_type = null;
 
 	/**
 	 * Creates an instance of this class
@@ -46,7 +46,7 @@ abstract class Strikebase_Fields {
 	 */
 	private function __construct() {
 		// Create the post type
-		add_action( 'init', array( $this, 'create_fields' ) );
+		add_action( 'fm_post_' . $this->post_type, array( $this, 'create_fields' ) );
 	}
 
 	/**


### PR DESCRIPTION
This probably doesn't really need a PR. I just updated the action hook used for the Custom Fields to hook into `fm_post_[post-type]` from Fieldmanager instead of `init`.

The branch name isn't even really accurate. I was thinking about the Taxonomies when I created it but that's another thing.