### PR TITLE
Fix for main nav slightly misaligned

### DIFF
--- a/assets/stylesheets/components/_navigation-main.scss
+++ b/assets/stylesheets/components/_navigation-main.scss
@@ -16,6 +16,7 @@
 
 	li {
 		text-align: center;
+		flex-grow: 1;
 	}
 
 	a {

--- a/style.css
+++ b/style.css
@@ -664,7 +664,9 @@ tr:nth-of-type(even) {
     max-width: 693.33333px;
     padding-left: 0; }
   .main-navigation li {
-    text-align: center; }
+    text-align: center;
+    -ms-flex-positive: 1;
+    flex-grow: 1; }
   .main-navigation a {
     color: #DBD4C6;
     display: block;


### PR DESCRIPTION
The main nav list items are a little bit off-centered because we're not using `flex-grow: 1;` on them. They're not expanding to take up the width of the flex container (<ul>). Adding that rule to the list items appears to sort it out.